### PR TITLE
Develop/task/19 try with returning try of t does not work well with nested try withs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "skala"
 
 organization := "io.kevinlee"
 
-val projectVersion = "0.0.4"
+val projectVersion = "0.0.5"
 
 version := projectVersion
 
@@ -23,10 +23,13 @@ scalacOptions ++= Seq(
   "-Ywarn-numeric-widen"      // Warn when numerics are widened.
 )
 
-libraryDependencies ++= List(
-//  "org.scala-lang" % "scala-library" % "2.11.7",
-//  "org.scala-lang" % "scala-reflect" % "2.11.7",
-//  "org.scala-lang.modules" % "scala-xml_2.11" % "1.0.4",
+libraryDependencies ++= Seq(
+//  "org.scala-lang" % "scala-compiler" % "2.11.8",
+//  "org.scala-lang" % "scala-library" % "2.11.8",
+//  "org.scala-lang" % "scala-reflect" % "2.11.8",
+//  "org.scala-lang.modules" % "scala-xml_2.11" % "1.0.5",
+//  "org.scala-lang.modules" % "scala-parser-combinators_2.11" % "1.0.4",
+
   "org.scalatest" % "scalatest_2.11" % "2.2.4" % "test",
   "com.storm-enroute" %% "scalameter" % "0.6",
   "org.scalamock" %% "scalamock-scalatest-support" % "3.2.2" % "test"

--- a/notes/0.0.5.md
+++ b/notes/0.0.5.md
@@ -1,7 +1,9 @@
 # Skala [v0.0.5](https://github.com/Kevin-Lee/skala/issues?q=milestone%3A0.0.5+is%3Aclosed)
 
 ## Fixed
-* tryWith should evaluate the parameter once (#17)
+* `tryWith` should evaluate the parameter once (#17)
 
 ## Changed
 * Update libs and plugins (#15)
+* ~~`tryWith` should return `Try[T]` instead of `T` (#18)~~ (dropped in favor of #19)
+* `tryWith` returning `Try[T]` does not work well with nested `tryWith`s (#19)

--- a/notes/0.0.5.md
+++ b/notes/0.0.5.md
@@ -4,6 +4,6 @@
 * `tryWith` should evaluate the parameter once (#17)
 
 ## Changed
-* Update libs and plugins (#15)
+* Update libs (#15)
 * ~~`tryWith` should return `Try[T]` instead of `T` (#18)~~ (dropped in favor of #19)
 * `tryWith` returning `Try[T]` does not work well with nested `tryWith`s (#19)

--- a/notes/0.0.5.md
+++ b/notes/0.0.5.md
@@ -1,0 +1,7 @@
+# Skala [v0.0.5](https://github.com/Kevin-Lee/skala/issues?q=milestone%3A0.0.5+is%3Aclosed)
+
+## Fixed
+* tryWith should evaluate the parameter once (#17)
+
+## Changed
+* Update libs and plugins (#15)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 0.13.11

--- a/src/main/scala/io/kevinlee/skala/package.scala
+++ b/src/main/scala/io/kevinlee/skala/package.scala
@@ -9,7 +9,7 @@ import scala.util.{Failure, Success, Try}
 package object skala {
 
   /**
-    * runs the given function with the given AuthoCloseable param then calls the AuthoCloseable.close().
+    * runs the given function with the given [[java.lang.AutoCloseable]] param then calls the [[java.lang.AutoCloseable#close()]].
     *
     * It is design to dispose the resource after it is used.
     * Reading and writing might be good examples of when this tryWith can be useful.
@@ -19,10 +19,38 @@ package object skala {
     * tryWith(new FileInputStream("/path/to/file.txt")) { inputStream =>
     *   var c = inputStream.read()
     *   while (c != -1) {
-    *     print(c.asInstanceOf[Char])
+    *     print(c.toChar)
     *     c = inputStream.read()
     *   }
     * }
+    * }}}
+    *
+    * {{{
+    *
+    * // content == result
+    * val content = tryWith(new FileInputStream("/tmp/kevin-test/old.csv")) { inputStream =>
+    *   var c = inputStream.read()
+    *   var result = Vector(c.toChar)
+    *   while (c != -1) {
+    *     c = inputStream.read()
+    *     result = result:+ c.toChar
+    *   }
+    *   result
+    * }
+    * }}}
+    *
+    * Or a better example might be
+    * {{{
+    * // content is Success(Vector) when it succeeds or Failure(Throwable) if it fails.
+    * val content = Try(tryWith(new FileInputStream("/tmp/kevin-test/old.csv")) { inputStream =>
+    *   var c = inputStream.read()
+    *   var result = Vector(c.toChar)
+    *   while (c != -1) {
+    *     c = inputStream.read()
+    *     result = result:+ c.toChar
+    *   }
+    *   result
+    * })
     * }}}
     *
     * {{{
@@ -31,32 +59,69 @@ package object skala {
     *
     *     var c = reader.read()
     *     while (c != -1) {
-    *       print(c.asInstanceOf[Char])
+    *       print(c.toChar)
     *       c = reader.read()
     *     }
     *   }
     * }
     * }}}
-    * @param closeable the given AutoCloseable object which is used by the given function.
-    * @param f         the function which does actual work after AuthoCloseable.close() is called.
-    * @tparam T Any AuthoCloseable type
-    * @tparam R The result returned by the given function f.
-    * @return Try[R] containing the result from the given function f if it succeeds or Throwable when it fails.
+    *
+    * {{{
+    * // content == result
+    * val content = tryWith(new FileInputStream("/path/to/file.txt")) { inputStream =>
+    *
+    *   tryWith(new InputStreamReader(inputStream)) { reader =>
+    *
+    *     var c = reader.read()
+    *     var result = Vector(c.toChar)
+    *     while (c != -1) {
+    *       c = inputStream.read()
+    *       result = result:+ c.toChar
+    *     }
+    *     result
+    *   }
+    * }
+    * }}}
+    *
+    * Or a better example might be
+    * {{{
+    * // content is Success(Vector) when it succeeds or Failure(Throwable) if it fails.
+    * val content = Try(tryWith(new FileInputStream("/path/to/file.txt")) { inputStream =>
+    *
+    *   tryWith(new InputStreamReader(inputStream)) { reader =>
+    *
+    *     var c = reader.read()
+    *     var result = Vector(c.toChar)
+    *     while (c != -1) {
+    *       c = inputStream.read()
+    *       result = result:+ c.toChar
+    *     }
+    *     result
+    *   }
+    * })
+    * }}}
+    *
+    * @param closeable The given [[java.lang.AutoCloseable]] object which is used by the given function.
+    * @param f         The function which does actual work before [[java.lang.AutoCloseable#close()]] is called.
+    * @tparam T        Any [[java.lang.AutoCloseable]] type
+    * @tparam R        The type of the result returned by the given function f.
+    * @return          The result from the given function f if it succeeds or it may throw an exception when it fails.
+    * @throws          Throwable when any Throwable was thrown. It depends on the given closeable or the function f.
     */
-  def tryWith[T <: AutoCloseable, R](closeable: => T)(f: T => R): Try[R] = {
-    Try(closeable) match {
-      case Success(resource) =>
-        val result = Try(f(resource))
-
+  def tryWith[T <: AutoCloseable, R](closeable: => T)(f: T => R): R =
+    Try(closeable) map { resource =>
+      try {
+        f(resource)
+      } finally {
         Try(resource.close()) match {
-          case Failure(ex) => println(ex)
+          case Failure(ex) =>
+            println(ex)
           case _ =>
         }
-        result
-
-      case failure =>
-        failure.asInstanceOf[Try[R]]
+      }
+    } match {
+      case Success(r) => r
+      case Failure(ex) => throw ex
     }
-  }
 
 }

--- a/src/main/scala/io/kevinlee/skala/package.scala
+++ b/src/main/scala/io/kevinlee/skala/package.scala
@@ -1,5 +1,7 @@
 package io.kevinlee
 
+import scala.util.{Failure, Success, Try}
+
 /**
   * @author Kevin Lee
   * @since 2016-05-08
@@ -35,21 +37,26 @@ package object skala {
     *   }
     * }
     * }}}
-    *
     * @param closeable the given AutoCloseable object which is used by the given function.
-    * @param f the function which does actual work after AuthoCloseable.close() is called.
+    * @param f         the function which does actual work after AuthoCloseable.close() is called.
     * @tparam T Any AuthoCloseable type
     * @tparam R The result returned by the given function f.
-    * @return The result from the given function f.
+    * @return Try[R] containing the result from the given function f if it succeeds or Throwable when it fails.
     */
-  def tryWith[T <: AutoCloseable, R](closeable: => T)(f: T => R): R = {
-    val resource = closeable
-    try {
-      f(resource)
-    } finally {
-      if (resource != null) {
-        resource.close()
-      }
+  def tryWith[T <: AutoCloseable, R](closeable: => T)(f: T => R): Try[R] = {
+    Try(closeable) match {
+      case Success(resource) =>
+        val result = Try(f(resource))
+
+        Try(resource.close()) match {
+          case Failure(ex) => println(ex)
+          case _ =>
+        }
+        result
+
+      case failure =>
+        failure.asInstanceOf[Try[R]]
     }
   }
+
 }

--- a/src/main/scala/io/kevinlee/skala/package.scala
+++ b/src/main/scala/io/kevinlee/skala/package.scala
@@ -43,11 +43,12 @@ package object skala {
     * @return The result from the given function f.
     */
   def tryWith[T <: AutoCloseable, R](closeable: => T)(f: T => R): R = {
+    val resource = closeable
     try {
-      f(closeable)
+      f(resource)
     } finally {
-      if (closeable != null) {
-        closeable.close()
+      if (resource != null) {
+        resource.close()
       }
     }
   }

--- a/src/test/scala/io/kevinlee/skala/math/package$Spec.scala
+++ b/src/test/scala/io/kevinlee/skala/math/package$Spec.scala
@@ -1,7 +1,7 @@
 package io.kevinlee.skala.math
 
-import org.scalatest.{BeforeAndAfterEach, WordSpec}
 import org.scalatest.Matchers._
+import org.scalatest.{BeforeAndAfterEach, WordSpec}
 
 import scala.language.postfixOps
 

--- a/src/test/scala/io/kevinlee/skala/package$Spec.scala
+++ b/src/test/scala/io/kevinlee/skala/package$Spec.scala
@@ -33,9 +33,6 @@ class package$Spec extends WordSpec with MockFactory {
         }
       }
     }
-  }
-
-  "tryWith" when {
 
     "tryWith(SomeResource) { // run block }" should {
 
@@ -55,9 +52,6 @@ class package$Spec extends WordSpec with MockFactory {
 
       }
     }
-  }
-
-  "tryWith" when {
 
     "val actual = tryWith(SomeResource) { // run block }" should {
 
@@ -78,10 +72,6 @@ class package$Spec extends WordSpec with MockFactory {
         assert(actual === expected)
       }
     }
-  }
-
-
-  "tryWith" when {
 
     """:
       |    tryWith(SomeResource) {
@@ -111,9 +101,6 @@ class package$Spec extends WordSpec with MockFactory {
 
       }
     }
-  }
-
-  "tryWith" when {
 
     """:
       |    val actual = tryWith(SomeResource) {
@@ -147,9 +134,6 @@ class package$Spec extends WordSpec with MockFactory {
         assert(actual === expected)
       }
     }
-  }
-
-  "tryWith" when {
 
     """anotherResource.close() does not call resource.close()
       |
@@ -184,6 +168,29 @@ class package$Spec extends WordSpec with MockFactory {
         assert(actual === expected)
       }
     }
+
+    var count = 0
+
+    case class CountableCloseable() extends AutoCloseable {
+      count += 1
+
+      def run(): Unit = ()
+
+      def close(): Unit = ()
+    }
+
+    "tryWith(an instantiation of a resource)" should {
+      "instantiate it once and use the same one" in {
+
+        tryWith(new CountableCloseable()) { resource =>
+          resource.run()
+        }
+
+        assert(count == 1)
+
+      }
+    }
+
   }
 
 }


### PR DESCRIPTION
## Fixed
* `tryWith` should evaluate the parameter once (#17)

## Changed
* Update libs (#15)
* ~~`tryWith` should return `Try[T]` instead of `T` (#18)~~ (dropped in favor of #19)
* `tryWith` returning `Try[T]` does not work well with nested `tryWith`s (#19)
