### PR TITLE
Skala v0.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "skala"
 organization := "io.kevinlee"
 
 val ProjectVersion = "0.2.0"
-val TheScalaVersion = "2.12.6"
+val TheScalaVersion = "2.12.8"
 
 version := ProjectVersion
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "skala"
 
 organization := "io.kevinlee"
 
-val ProjectVersion = "0.1.0"
+val ProjectVersion = "0.2.0"
 val TheScalaVersion = "2.12.6"
 
 version := ProjectVersion

--- a/notes/0.2.0.md
+++ b/notes/0.2.0.md
@@ -1,0 +1,4 @@
+# Skala [v0.2.0](https://github.com/Kevin-Lee/skala/issues?utf8=%E2%9C%93&q=milestone%3A0.2.0%20is%3Aclosed)
+
+## Done
+* tryWith should work the same as Java's try-with-resources and remove TryWith (#55)

--- a/src/test/scala-2.12/io/kevinlee/skala/util/SideEffectSpec.scala
+++ b/src/test/scala-2.12/io/kevinlee/skala/util/SideEffectSpec.scala
@@ -150,7 +150,7 @@ class SideEffectSpec extends WordSpec with Matchers with MockFactory {
           (resource.close _: () => Unit) expects() twice()
         }
 
-        val actual = tryWith(resource) { someResource =>
+        val actual = tryWith(resource) { _ =>
           tryWith(anotherResource) { someOtherResource =>
             someOtherResource.run()
           }
@@ -213,7 +213,7 @@ class SideEffectSpec extends WordSpec with Matchers with MockFactory {
           (resource.close _: () => Unit) expects() once()
         }
 
-        val actual = tryWith(resource) { someResource =>
+        val actual = tryWith(resource) { _ =>
           tryWith(anotherResource) { someOtherResource =>
             someOtherResource.run()
           }
@@ -266,7 +266,7 @@ class SideEffectSpec extends WordSpec with Matchers with MockFactory {
           tryWith(resource) { someResource =>
             tryWith(new AutoCloseable {
               override def close(): Unit = ()
-            }) { anotherResource =>
+            }) { _ =>
               someResource.run()
             }
             throw AnotherTryTestException
@@ -484,7 +484,7 @@ class SideEffectSpec extends WordSpec with Matchers with MockFactory {
           (resource.close _: () => Unit) expects() twice()
         }
 
-        val actual = Try(tryWith(resource) { someResource =>
+        val actual = Try(tryWith(resource) { _ =>
           tryWith(anotherResource) { someOtherResource =>
             someOtherResource.run()
           }
@@ -515,7 +515,7 @@ class SideEffectSpec extends WordSpec with Matchers with MockFactory {
           (resource.close _: () => Unit) expects() once()
         }
 
-        val actual = Try(tryWith(resource) { someResource =>
+        val actual = Try(tryWith(resource) { _ =>
           tryWith(anotherResource) { someOtherResource =>
             someOtherResource.run()
           }
@@ -571,7 +571,7 @@ class SideEffectSpec extends WordSpec with Matchers with MockFactory {
         val actual = Try(tryWith(resource) { someResource =>
           tryWith(new AutoCloseable {
             override def close(): Unit = ()
-          }) { anotherResource =>
+          }) { _ =>
             someResource.run()
           }
           throw AnotherTryTestException


### PR DESCRIPTION
Skala v0.2.0
============
Done
----
* tryWith should work the same as Java's try-with-resources and remove TryWith (#55)
